### PR TITLE
Introduce VisibilityState Interface and Composable Utilities for Visibility Management

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -97,6 +97,7 @@ kotlin {
       implementation(libs.androidx.lifecycle.runtime.compose)
 
       implementation(projects.crosslensCore)
+      implementation(projects.crosslensUi)
     }
     desktopMain.dependencies {
       implementation(compose.desktop.currentOs)

--- a/composeApp/src/commonMain/kotlin/dev/teogor/crosslens/App.kt
+++ b/composeApp/src/commonMain/kotlin/dev/teogor/crosslens/App.kt
@@ -23,9 +23,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import dev.teogor.crosslens.ui.rememberVisibilityState
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 private const val VERSION = "1.0.0-alpha01"
@@ -38,6 +41,12 @@ private val FEATURES = listOf(
 @Composable
 @Preview
 public fun App() {
+  val visibility by rememberVisibilityState(true)
+  LaunchedEffect(Unit) {
+    visibility.hide()
+    visibility.show()
+    visibility.toggle()
+  }
   MaterialTheme {
     Surface(
       modifier = Modifier.fillMaxSize(),

--- a/crosslens-ui/api/android/crosslens-ui.api
+++ b/crosslens-ui/api/android/crosslens-ui.api
@@ -1,0 +1,16 @@
+public abstract interface class dev/teogor/crosslens/ui/VisibilityState {
+	public abstract fun getScope ()Lkotlinx/coroutines/CoroutineScope;
+	public abstract fun hide ()V
+	public abstract fun isVisible ()Z
+	public abstract fun show ()V
+	public abstract fun toggle ()V
+}
+
+public abstract interface class dev/teogor/crosslens/ui/VisibilityState$Factory {
+	public abstract fun create (Z)Ldev/teogor/crosslens/ui/VisibilityState;
+}
+
+public final class dev/teogor/crosslens/ui/VisibilityStateKt {
+	public static final fun rememberVisibilityState (ZLandroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/MutableState;
+}
+

--- a/crosslens-ui/api/jvm/crosslens-ui.api
+++ b/crosslens-ui/api/jvm/crosslens-ui.api
@@ -1,0 +1,16 @@
+public abstract interface class dev/teogor/crosslens/ui/VisibilityState {
+	public abstract fun getScope ()Lkotlinx/coroutines/CoroutineScope;
+	public abstract fun hide ()V
+	public abstract fun isVisible ()Z
+	public abstract fun show ()V
+	public abstract fun toggle ()V
+}
+
+public abstract interface class dev/teogor/crosslens/ui/VisibilityState$Factory {
+	public abstract fun create (Z)Ldev/teogor/crosslens/ui/VisibilityState;
+}
+
+public final class dev/teogor/crosslens/ui/VisibilityStateKt {
+	public static final fun rememberVisibilityState (ZLandroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/MutableState;
+}
+

--- a/crosslens-ui/build.gradle.kts
+++ b/crosslens-ui/build.gradle.kts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerToolOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+plugins {
+  alias(libs.plugins.jetbrains.kotlin.multiplatform)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.jetbrains.compose)
+  alias(libs.plugins.jetbrains.compose.compiler)
+  alias(libs.plugins.teogor.winds)
+}
+
+winds {
+  moduleMetadata {
+    artifactDescriptor {
+      name = "UI"
+    }
+  }
+}
+
+kotlin {
+  explicitApi()
+
+  applyDefaultHierarchyTemplate()
+
+  jvm {
+    kotlin {
+      jvmToolchain(11)
+    }
+  }
+
+  js(IR) {
+    browser()
+    nodejs()
+  }
+
+  @OptIn(ExperimentalWasmDsl::class)
+  wasmJs {
+    browser()
+    nodejs()
+    binaries.executable()
+  }
+
+  androidTarget {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_11)
+    }
+  }
+
+  listOf(
+    iosX64(),
+    iosArm64(),
+    iosSimulatorArm64()
+  ).forEach { target ->
+    target.binaries.framework {
+      baseName = "crosslens-ui"
+    }
+  }
+
+  macosX64()
+  macosArm64()
+
+  sourceSets {
+    commonMain.dependencies {
+      implementation(compose.runtime)
+      implementation(compose.ui)
+
+      implementation(libs.kotlinx.coroutines.core)
+    }
+  }
+}
+
+android {
+  namespace = "dev.teogor.crosslens.ui"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+  defaultConfig {
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+
+  kotlin {
+    jvmToolchain(11)
+  }
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
+  }
+}

--- a/crosslens-ui/src/commonMain/kotlin/dev/teogor/crosslens/ui/VisibilityState.kt
+++ b/crosslens-ui/src/commonMain/kotlin/dev/teogor/crosslens/ui/VisibilityState.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Typealias for a provider function that creates a [VisibilityState.Factory] instance.
+ *
+ * @param T The type of [VisibilityState] to create.
+ */
+public typealias VisibilityStateFactoryProvider<T> = @DisallowComposableCalls () -> VisibilityState.Factory<T>
+
+/**
+ * Interface defining the contract for managing visibility state and behavior.
+ *
+ * Provides methods to control the visibility state:
+ * - [show]: Sets the visibility to `true`.
+ * - [hide]: Sets the visibility to `false`.
+ * - [toggle]: Toggles the current visibility state.
+ * - [isVisible]: Indicates whether the controlled entity is currently visible.
+ */
+public interface VisibilityState {
+
+  /**
+   * The [CoroutineScope] associated with this visibility state, used for launching coroutines.
+   */
+  public val scope: CoroutineScope
+
+  /**
+   * Indicates whether the controlled entity is currently visible.
+   */
+  public val isVisible: Boolean
+
+  /**
+   * Shows the controlled entity, setting its visibility to `true`.
+   */
+  public fun show()
+
+  /**
+   * Hides the controlled entity, setting its visibility to `false`.
+   */
+  public fun hide()
+
+  /**
+   * Toggles the visibility state of the controlled entity.
+   * If currently visible, hides it; if hidden, shows it.
+   */
+  public fun toggle()
+
+  /**
+   * Factory interface for creating instances of [VisibilityState].
+   */
+  public interface Factory<T : VisibilityState> {
+    /**
+     * Creates a new instance of [VisibilityState] with the given initial state.
+     *
+     * @param initialState The initial visibility state of the controller.
+     * @return A new instance of [VisibilityState] with the specified initial state.
+     */
+    public fun create(initialState: Boolean): T
+  }
+}
+
+/**
+ * Default implementation of [VisibilityState] that manages visibility state.
+ *
+ * Provides basic methods to control visibility: [show], [hide], and [toggle].
+ *
+ * @param initialState The initial visibility state. Defaults to `false`.
+ */
+private class VisibilityStateImpl(
+  initialState: Boolean = false,
+) : VisibilityState {
+  private val _isVisible = mutableStateOf(initialState)
+  override val isVisible: Boolean get() = _isVisible.value
+  override val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+  override fun show() {
+    _isVisible.value = true
+  }
+
+  override fun hide() {
+    _isVisible.value = false
+  }
+
+  override fun toggle() {
+    _isVisible.value = !_isVisible.value
+  }
+}
+
+/**
+ * Provides a [MutableState] of [VisibilityState] that is remembered across recompositions.
+ *
+ * This function creates and remembers a [VisibilityStateImpl] instance, which manages
+ * the visibility state with the specified initial state.
+ *
+ * @param initialState The initial visibility state. Defaults to `false`.
+ * @return A [MutableState] containing the remembered [VisibilityStateImpl] instance.
+ */
+@Composable
+public fun rememberVisibilityState(
+  initialState: Boolean = false
+): MutableState<VisibilityState> {
+  return remember {
+    mutableStateOf(VisibilityStateImpl(initialState))
+  }
+}
+
+/**
+ * Provides a [MutableState] of [VisibilityState] using the provided [factory] to create it.
+ *
+ * This function is used to retain a mutable state of a [VisibilityState] within a Composable
+ * function. The [factory] is responsible for creating instances of [VisibilityState],
+ * allowing flexibility in how different types of visibility states are instantiated and managed.
+ *
+ * @param initialState The initial visibility state for the state.
+ * @param factory A factory interface that creates instances of [VisibilityState].
+ * @return A mutable state holding the instance of [VisibilityState].
+ */
+@Composable
+public inline fun <reified T : VisibilityState> rememberVisibilityState(
+  initialState: Boolean = false,
+  factory: VisibilityState.Factory<T>
+): MutableState<T> {
+  return remember {
+    mutableStateOf(factory.create(initialState))
+  }
+}
+
+/**
+ * Provides a [MutableState] of [VisibilityState] using a factory provider function to create it.
+ *
+ * This function retains a mutable state of a [VisibilityState] within a Composable function.
+ * The [factoryProvider] function is used to create instances of [VisibilityState.Factory],
+ * allowing for flexible instantiation.
+ *
+ * @param initialState The initial visibility state for the state.
+ * @param factoryProvider A function to provide the [VisibilityState.Factory] for creating instances of [VisibilityState].
+ * @return A mutable state holding the instance of [VisibilityState].
+ */
+@Composable
+public inline fun <reified T : VisibilityState> rememberVisibilityState(
+  initialState: Boolean = false,
+  crossinline factoryProvider: VisibilityStateFactoryProvider<T>
+): MutableState<T> {
+  return remember {
+    mutableStateOf(factoryProvider().create(initialState))
+  }
+}
+
+/**
+ * Configures a [MutableState] of type [VisibilityState] with a configuration block.
+ *
+ * Applies the provided configuration block to the [VisibilityState] instance,
+ * ensuring that it is applied on recomposition.
+ *
+ * @param block The configuration block to apply to the [VisibilityState] instance.
+ * @return The same [MutableState] with the applied configuration.
+ */
+@OptIn(ExperimentalContracts::class)
+@Composable
+public inline fun <reified T : VisibilityState> MutableState<T>.withConfiguration(
+  noinline block: @DisallowComposableCalls T.() -> Unit,
+): MutableState<T> {
+  contract {
+    returns() implies (this@withConfiguration is T)
+  }
+
+  // Remember the latest block to apply
+  val updatedBlock by rememberUpdatedState(block)
+
+  // Apply the configuration to the state
+  LaunchedEffect(updatedBlock) {
+    value.updatedBlock()
+  }
+
+  return this
+}

--- a/docs/ui-overview.md
+++ b/docs/ui-overview.md
@@ -1,0 +1,118 @@
+# CrossLens UI
+
+`crosslens-ui` is a Kotlin-based package designed for managing UI components and their visibility
+states within a Jetpack Compose application. It provides a set of utilities and classes that
+simplify the control and handling of visibility states, ensuring a smooth user experience.
+
+## Installation
+
+To use the `crosslens-ui` package, add the following dependency to your `build.gradle.kts`:
+
+```kotlin
+dependencies {
+  implementation("dev.teogor.crosslens:crosslens-ui:$version")
+}
+```
+
+## Usage
+
+### VisibilityState
+
+The `VisibilityState` interface is a core component of the `crosslens-ui` package. It defines a
+contract for managing the visibility of UI components, allowing developers to show, hide, and toggle
+visibility with ease.
+
+#### Defining a VisibilityState
+
+The default implementation of `VisibilityState` is `VisibilityStateImpl`, which can be remembered
+across recompositions using the `rememberVisibilityState` function.
+
+```kotlin
+@Composable
+fun MyComponent() {
+  val visibilityState by rememberVisibilityState()
+
+  // Show the component
+  visibilityState.show()
+
+  // Hide the component
+  visibilityState.hide()
+
+  // Toggle the component's visibility
+  visibilityState.toggle()
+}
+```
+
+#### Custom VisibilityState
+
+You can create your own implementation of `VisibilityState` by extending the interface. This is
+useful when you need to manage additional properties alongside visibility.
+
+For example, here’s a custom implementation called `MenuVisibility`:
+
+```kotlin
+class MenuVisibility(
+  initialState: Boolean = false,
+) : VisibilityState {
+  // Custom properties
+  private val _isVisible = mutableStateOf(initialState)
+  override val isVisible: Boolean get() = _isVisible.value
+
+  override val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+  override fun show() {
+    _isVisible.value = true
+  }
+
+  override fun hide() {
+    _isVisible.value = false
+  }
+
+  override fun toggle() {
+    _isVisible.value = !isVisible
+  }
+
+  companion object Factory : VisibilityState.Factory<MenuVisibility> {
+    override fun create(initialState: Boolean): MenuVisibility {
+      return MenuVisibility(initialState)
+    }
+  }
+}
+```
+
+#### Remembering a Custom VisibilityState
+
+To remember a custom `VisibilityState` instance, use the `rememberVisibilityState` function with a
+factory or factory provider:
+
+```kotlin
+@Composable
+fun MyMenuComponent() {
+  val menuVisibility by rememberVisibilityState(factory = MenuVisibility)
+  // Or
+  val menuVisibility by rememberVisibilityState { MenuVisibility }
+
+  // Use the visibility state
+  if (menuVisibility.isVisible) {
+    // Render your menu
+  }
+}
+```
+
+### Advanced Configuration
+
+You can apply additional configurations to your `VisibilityState` instance by using
+the `withConfiguration` extension function:
+
+```kotlin
+@Composable
+fun MyConfigurableComponent() {
+  val visibilityState = rememberVisibilityState()
+    .withConfiguration {
+      // Apply custom configurations here
+      toggle()
+    }
+
+  // Use the configured visibility state
+}
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ android.useAndroidX=true
 #Kotlin Multiplatform
 kotlin.mpp.enableCInteropCommonization=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.macos.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,3 +34,4 @@ dependencyResolutionManagement {
 include(":composeApp")
 
 include(":crosslens-core")
+include(":crosslens-ui")


### PR DESCRIPTION
### Summary

This pull request adds a `VisibilityState` interface and a set of associated Composable utilities to manage and control visibility state within Jetpack Compose applications. These utilities provide a structured way to manage visibility using a `VisibilityState` interface, along with several functions to remember and configure visibility state in a Composable context.

### Key Additions

- **VisibilityState Interface**: Defines the contract for managing visibility state, including methods to `show`, `hide`, `toggle`, and check if an entity is currently visible.
- **VisibilityStateImpl**: A private implementation of `VisibilityState` that provides default behavior for visibility management.
- **rememberVisibilityState Functions**: Multiple overloads of `rememberVisibilityState` allow for remembering visibility state with or without a factory, enabling flexible instantiation and state retention across recompositions.
- **withConfiguration Extension Function**: Provides a way to configure a `VisibilityState` within a Composable function, applying configuration blocks with support for re-composition.

