### PR TITLE
Introduce Support for Platform-Specific Class Name Formats

### DIFF
--- a/crosslens-core/api/android/crosslens-core.api
+++ b/crosslens-core/api/android/crosslens-core.api
@@ -18,6 +18,24 @@ public final class dev/teogor/crosslens/core/HashCodeBuilderKt {
 	public static final fun lazyHashCode (Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
 }
 
+public final class dev/teogor/crosslens/core/KClassKtx_androidKt {
+	public static final fun getFormattedName (Lkotlin/reflect/KClass;Ldev/teogor/crosslens/core/NameFormat;)Ljava/lang/String;
+	public static synthetic fun getFormattedName$default (Lkotlin/reflect/KClass;Ldev/teogor/crosslens/core/NameFormat;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class dev/teogor/crosslens/core/KClassKtx_commonKt {
+	public static final fun getMultiplatformName (Lkotlin/reflect/KClass;)Ljava/lang/String;
+}
+
+public final class dev/teogor/crosslens/core/NameFormat : java/lang/Enum {
+	public static final field MULTIPLATFORM Ldev/teogor/crosslens/core/NameFormat;
+	public static final field QUALIFIED Ldev/teogor/crosslens/core/NameFormat;
+	public static final field SIMPLE Ldev/teogor/crosslens/core/NameFormat;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/crosslens/core/NameFormat;
+	public static fun values ()[Ldev/teogor/crosslens/core/NameFormat;
+}
+
 public final class dev/teogor/crosslens/core/startup/ActivityInitializer : androidx/startup/Initializer {
 	public fun <init> ()V
 	public synthetic fun create (Landroid/content/Context;)Ljava/lang/Object;

--- a/crosslens-core/api/jvm/crosslens-core.api
+++ b/crosslens-core/api/jvm/crosslens-core.api
@@ -13,3 +13,21 @@ public final class dev/teogor/crosslens/core/HashCodeBuilderKt {
 	public static final fun lazyHashCode (Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
 }
 
+public final class dev/teogor/crosslens/core/KClassKtx_commonKt {
+	public static final fun getMultiplatformName (Lkotlin/reflect/KClass;)Ljava/lang/String;
+}
+
+public final class dev/teogor/crosslens/core/KClassKtx_jvmKt {
+	public static final fun getFormattedName (Lkotlin/reflect/KClass;Ldev/teogor/crosslens/core/NameFormat;)Ljava/lang/String;
+	public static synthetic fun getFormattedName$default (Lkotlin/reflect/KClass;Ldev/teogor/crosslens/core/NameFormat;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class dev/teogor/crosslens/core/NameFormat : java/lang/Enum {
+	public static final field MULTIPLATFORM Ldev/teogor/crosslens/core/NameFormat;
+	public static final field QUALIFIED Ldev/teogor/crosslens/core/NameFormat;
+	public static final field SIMPLE Ldev/teogor/crosslens/core/NameFormat;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/crosslens/core/NameFormat;
+	public static fun values ()[Ldev/teogor/crosslens/core/NameFormat;
+}
+

--- a/crosslens-core/src/androidMain/kotlin/dev/teogor/crosslens/core/KClassKtx.android.kt
+++ b/crosslens-core/src/androidMain/kotlin/dev/teogor/crosslens/core/KClassKtx.android.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Provides the class name in a specified format. The [format] parameter allows for different
+ * naming conventions, including fully qualified names, simple names, and platform-specific
+ * formats.
+ *
+ * @param format Specifies the format for the class name. Defaults to [NameFormat.QUALIFIED].
+ * @return The class name as a [String] in the specified format, or `null` if the name cannot
+ * be determined.
+ */
+public actual fun KClass<*>.getFormattedName(format: NameFormat): String? {
+  return when (format) {
+    NameFormat.QUALIFIED -> qualifiedName
+    NameFormat.SIMPLE -> simpleName
+    NameFormat.MULTIPLATFORM -> qualifiedName
+  }
+}

--- a/crosslens-core/src/commonMain/kotlin/dev/teogor/crosslens/core/KClassKtx.common.kt
+++ b/crosslens-core/src/commonMain/kotlin/dev/teogor/crosslens/core/KClassKtx.common.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Defines the various formats for class name representation.
+ */
+public enum class NameFormat {
+  /**
+   * Fully qualified name of the class, including the package.
+   */
+  QUALIFIED,
+
+  /**
+   * Simple name of the class, without the package.
+   */
+  SIMPLE,
+
+  /**
+   * A platform-specific name format. This can be used to implement custom naming
+   * conventions that may vary by platform or environment.
+   */
+  MULTIPLATFORM
+}
+
+/**
+ * Provides the class name in a specified format. The [format] parameter allows for different
+ * naming conventions, including fully qualified names, simple names, and platform-specific
+ * formats.
+ *
+ * @param format Specifies the format for the class name. Defaults to [NameFormat.QUALIFIED].
+ * @return The class name as a [String] in the specified format, or `null` if the name cannot
+ * be determined.
+ */
+public expect fun KClass<*>.getFormattedName(format: NameFormat = NameFormat.QUALIFIED): String?
+
+/**
+ * Extension property that provides the platform-specific name for the class.
+ *
+ * This property retrieves the class name in a format that is tailored to be
+ * appropriate for the current platform or environment. It is a shorthand for
+ * calling [getFormattedName] with the [NameFormat.MULTIPLATFORM] format.
+ *
+ * The `MULTIPLATFORM` format is intended to support naming conventions that may vary
+ * depending on the platform or use case. This can be useful when different platforms
+ * require different representations of class names for various reasons, such as logging,
+ * serialization, or platform-specific APIs.
+ *
+ * @return The platform-specific name of the class as a [String], or `null` if the name
+ * cannot be determined or is not applicable in the current context.
+ *
+ * @see getFormattedName
+ * @see NameFormat.MULTIPLATFORM
+ */
+public val KClass<*>.multiplatformName: String?
+  get() = getFormattedName(NameFormat.MULTIPLATFORM)

--- a/crosslens-core/src/jsMain/kotlin/dev/teogor/crosslens/core/KClassKtx.js.kt
+++ b/crosslens-core/src/jsMain/kotlin/dev/teogor/crosslens/core/KClassKtx.js.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Provides the class name in a specified format. The [format] parameter allows for different
+ * naming conventions, including fully qualified names, simple names, and platform-specific
+ * formats.
+ *
+ * @param format Specifies the format for the class name. Defaults to [NameFormat.QUALIFIED].
+ * @return The class name as a [String] in the specified format, or `null` if the name cannot
+ * be determined.
+ */
+public actual fun KClass<*>.getFormattedName(format: NameFormat): String? {
+  return when (format) {
+    NameFormat.QUALIFIED -> simpleName
+    NameFormat.SIMPLE -> simpleName
+    NameFormat.MULTIPLATFORM -> simpleName
+  }
+}

--- a/crosslens-core/src/jvmMain/kotlin/dev/teogor/crosslens/core/KClassKtx.jvm.kt
+++ b/crosslens-core/src/jvmMain/kotlin/dev/teogor/crosslens/core/KClassKtx.jvm.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Provides the class name in a specified format. The [format] parameter allows for different
+ * naming conventions, including fully qualified names, simple names, and platform-specific
+ * formats.
+ *
+ * @param format Specifies the format for the class name. Defaults to [NameFormat.QUALIFIED].
+ * @return The class name as a [String] in the specified format, or `null` if the name cannot
+ * be determined.
+ */
+public actual fun KClass<*>.getFormattedName(format: NameFormat): String? {
+  return when (format) {
+    NameFormat.QUALIFIED -> qualifiedName
+    NameFormat.SIMPLE -> simpleName
+    NameFormat.MULTIPLATFORM -> qualifiedName
+  }
+}

--- a/crosslens-core/src/nativeMain/kotlin/dev/teogor/crosslens/core/KClassKtx.native.kt
+++ b/crosslens-core/src/nativeMain/kotlin/dev/teogor/crosslens/core/KClassKtx.native.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Provides the class name in a specified format. The [format] parameter allows for different
+ * naming conventions, including fully qualified names, simple names, and platform-specific
+ * formats.
+ *
+ * @param format Specifies the format for the class name. Defaults to [NameFormat.QUALIFIED].
+ * @return The class name as a [String] in the specified format, or `null` if the name cannot
+ * be determined.
+ */
+public actual fun KClass<*>.getFormattedName(format: NameFormat): String? {
+  return when (format) {
+    NameFormat.QUALIFIED -> qualifiedName
+    NameFormat.SIMPLE -> simpleName
+    NameFormat.MULTIPLATFORM -> qualifiedName
+  }
+}

--- a/crosslens-core/src/wasmJsMain/kotlin/dev/teogor/crosslens/core/KClassKtx.wasmJs.kt
+++ b/crosslens-core/src/wasmJsMain/kotlin/dev/teogor/crosslens/core/KClassKtx.wasmJs.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.crosslens.core
+
+import kotlin.reflect.KClass
+
+/**
+ * Provides the class name in a specified format. The [format] parameter allows for different
+ * naming conventions, including fully qualified names, simple names, and platform-specific
+ * formats.
+ *
+ * @param format Specifies the format for the class name. Defaults to [NameFormat.QUALIFIED].
+ * @return The class name as a [String] in the specified format, or `null` if the name cannot
+ * be determined.
+ */
+public actual fun KClass<*>.getFormattedName(format: NameFormat): String? {
+  return when (format) {
+    NameFormat.QUALIFIED -> simpleName
+    NameFormat.SIMPLE -> simpleName
+    NameFormat.MULTIPLATFORM -> simpleName
+  }
+}


### PR DESCRIPTION
### Summary

This pull request introduces support for various class name formats, including platform-specific naming conventions. It adds functionality for retrieving class names in different formats such as fully qualified names, simple names, and custom platform-specific formats.

### Key Additions

- **NameFormat Enum**: Defines the possible formats for class name representation:
  - `QUALIFIED`: Fully qualified name including the package.
  - `SIMPLE`: Simple name without the package.
  - `MULTIPLATFORM`: Platform-specific name format for custom naming conventions.

- **getFormattedName Function**: An `expect` function that retrieves the class name in the specified format. This function supports different naming conventions based on the provided `NameFormat`.

- **multiplatformName Extension Property**: Provides a shorthand for retrieving the platform-specific class name by calling `getFormattedName` with the `NameFormat.MULTIPLATFORM` format. This is useful for scenarios where naming conventions may vary depending on the platform or environment.

